### PR TITLE
Add publish to storage during function app deployment

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+SCM_POST_DEPLOYMENT_ACTIONS_PATH=deployment

--- a/Client/index.html
+++ b/Client/index.html
@@ -63,7 +63,7 @@
                                 <h3 style="padding-top: 0px; margin-top: 0px;">Instructions</h3>
                                 <ol>
                                     <li>Enter a name for Team 1 and Team 2 and click the <strong>Let's Play</strong> button.</li>
-                                    <li>Instruct your players to visit <mark><strong><a href="https://aka.ms/playtugofwar" target="_blank">https://aka.ms/playtugofwar</a></strong></mark> to start playing!</li>
+                                    <li>Instruct your players to visit <mark><strong><a id="playlink" href="/play.html" target="_blank"></a></strong></mark> to start playing!</li>
                                     <li>To start a new game simply refresh this page.</li>
                                 </ol>
                             </div>     

--- a/Client/index.js
+++ b/Client/index.js
@@ -1,6 +1,7 @@
 $( document ).ready(function() {
     // do nothing...
-    setGameArea(); 
+    setGameArea();
+    setPlayUrl();
 });
 
 var gameAreaWidth = 0;
@@ -162,3 +163,8 @@ var isWinningTeam = function() {
 var rinseRepeat = function() {
     setTimeout(updateScore, 1000);
 };
+
+function setPlayUrl() {
+    var playLink = document.getElementById('playlink');
+    playLink.innerText = playLink.href;
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -52,13 +52,13 @@
                             "value": "[variables('contentShareName')]"
                         },
                         {
-                            "name": "ROUTING_EXTENSION_VERSION",
-                            "value": "~0.1"
-                        },
-                        {
                             "name": "mycontainer_uri",
                             "value": "[concat(variables('storageName'),'.blob.core.windows.net')]"
-                        }                        
+                        },
+                        {
+                            "name": "STORAGE_KEY",
+                            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageName')), '2015-05-01-preview').key1]"
+                        }                       
                     ]
                 },
                 "clientAffinityEnabled": false

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -14,13 +14,17 @@
             "metadata": {
                 "description": "The location to use for creating the function app and hosting plan. It must be one of the Azure locations that support function apps."
             }
+        },
+        "repoUrl": {
+            "type": "string"
+        },
+        "branch": {
+            "type": "string"
         }
     },
     "variables": {
         "storageName": "[concat('function', uniqueString(parameters('siteName')))]",
-        "contentShareName": "[toLower(parameters('siteName'))]",
-        "repoUrl": "https://github.com/joescars/TugOfWar-FunctionsDemo.git",
-        "branch": "master"
+        "contentShareName": "[toLower(parameters('siteName'))]"
     },
     "resources": [
         {
@@ -72,8 +76,8 @@
                         "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "RepoUrl": "[variables('repoURL')]",
-                        "branch": "[variables('branch')]",
+                        "RepoUrl": "[parameters('repoUrl')]",
+                        "branch": "[parameters('branch')]",
                         "IsManualIntegration": true
                     }
                 }

--- a/deployment/deploy-content-to-storage.ps1
+++ b/deployment/deploy-content-to-storage.ps1
@@ -1,0 +1,10 @@
+$ProgressPreference="SilentlyContinue"
+
+$containerName = "content"
+$destinationUri = "https://$($Env:mycontainer_uri)/$containerName"
+$destinationKey = $Env:STORAGE_KEY
+D:\devtools\AzCopy\AzCopy.exe /Source:.\Client /Dest:$destinationUri /DestKey:$destinationKey /SetContentType /S /Y
+if ($LastExitCode -ne 0) { throw "azcopy returned code $($LastExitCode)" }
+
+$storageContext = New-AzureStorageContext -ConnectionString $Env:AzureWebJobsStorage -ErrorAction Stop
+Set-AzureStorageContainerAcl -Container $containerName -Permission Blob -Context $storageContext -ErrorAction Stop

--- a/proxies.json
+++ b/proxies.json
@@ -48,6 +48,16 @@
                 ]
             },
             "backendUri": "https://%WEBSITE_HOSTNAME%/api/GetTeamSettings"
+        },
+        "default": {
+            "matchCondition": {
+                "route": "/",
+                "methods": [
+                    "GET",
+                    "OPTIONS"
+                ]
+            },
+            "backendUri": "https://%mycontainer_uri%/content/index.html"
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ The following concepts are covered through this demo:
 ## Setup Instructions ##
 
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.svg)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoescars%2FTugOfWar-FunctionsDemo%2Fmaster%2Fazuredeploy.json)
+[![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://azuredeploy.net/)
 
 1. Click *Deploy to Azure* above to deploy directly to your Azure subscription.
 2. Once deployed, you must manually create a storage container called **content** and upload all the files inside the *client* folder. 

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,6 @@ The following concepts are covered through this demo:
 
 [![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://azuredeploy.net/)
 
-1. Click *Deploy to Azure* above to deploy directly to your Azure subscription.
-2. Once deployed, you must manually create a storage container called **content** and upload all the files inside the *client* folder. 
-    - I recommend using the [Azure Storage Explorer](http://storageexplorer.com/). 
-3. Make sure to **change the url** in *index.html* where it says "Instruct your players to visit" to your shorturl or direct link to your *play.html* page. 
-
 ## How to Play ##
 
 - From the home page (*index.html*) the presenter creates two Teams. For example. Team A and Team B. 

--- a/readme.md
+++ b/readme.md
@@ -61,4 +61,4 @@ Behind the scenes we are using Azure Functions with Storage Queues, Table Storag
 - Contact me on twitter [@joescars](https://www.twitter.com/joescars)
 
 ## Easy Deploy ##
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.svg)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoescars%2FTugOfWar-FunctionsDemo%2Fmaster%2Fazuredeploy.json)
+[![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://azuredeploy.net/)

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,6 @@ The following concepts are covered through this demo:
 
 ## Setup Instructions ##
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.svg)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoescars%2FTugOfWar-FunctionsDemo%2Fmaster%2Fazuredeploy.json)
 [![Deploy to Azure](https://azuredeploy.net/deploybutton.svg)](https://azuredeploy.net/)
 
 1. Click *Deploy to Azure* above to deploy directly to your Azure subscription.


### PR DESCRIPTION
- Added a PowerShell script to upload files to storage using azcopy.
- Made a couple of changes so that the app will deploy and be fully functional without modification:
    - Changed Deploy to Azure buttons to use deploy.azure.com and removed hardcoded repo URL and branch so it'll deploy from the fork/branch from which the button was clicked. This may break the deploy button on function library. @jefking 
    - Removed hardcoded link to the play page and replaced with dynamically generated one.
    - Added a route to the proxy at the root so link displayed after deployment leads directly to home page.
- Removed instructions on how to upload to blob storage.

Test out the button on this branch:
https://github.com/anthonychu/TugOfWar-FunctionsDemo/tree/add-storage-publish
